### PR TITLE
Fix misuse of render and renderTemplate view functions

### DIFF
--- a/packages/attachment/src/Charcoal/Attachment/Object/Attachment.php
+++ b/packages/attachment/src/Charcoal/Attachment/Object/Attachment.php
@@ -382,7 +382,7 @@ class Attachment extends Content implements AttachableInterface
      */
     public function heading()
     {
-        $heading = $this->render((string)$this->heading);
+        $heading = $this->renderTemplate((string)$this->heading);
 
         if (!$heading) {
             $heading = $this->translator()->translation('{{ objType }} #{{ id }}', [
@@ -425,7 +425,7 @@ class Attachment extends Content implements AttachableInterface
     public function preview()
     {
         if ($this->preview) {
-            return $this->render((string)$this->preview);
+            return $this->renderTemplate((string)$this->preview);
         }
 
         return '';

--- a/packages/email/src/Charcoal/Email/Email.php
+++ b/packages/email/src/Charcoal/Email/Email.php
@@ -909,7 +909,7 @@ class Email extends AbstractEntity implements
     /**
      * Get the email's HTML message from the template, if applicable.
      *
-     * @see    ViewableInterface::renderTemplate()
+     * @see    ViewableInterface::render()
      * @return string
      */
     protected function generateMsgHtml(): string
@@ -919,7 +919,7 @@ class Email extends AbstractEntity implements
         if (!$templateIdent) {
             $message = '';
         } else {
-            $message = $this->renderTemplate($templateIdent);
+            $message = $this->render($templateIdent);
         }
 
         return $message;

--- a/packages/object/src/Charcoal/Object/RoutableTrait.php
+++ b/packages/object/src/Charcoal/Object/RoutableTrait.php
@@ -277,7 +277,7 @@ trait RoutableTrait
     protected function generateRoutePattern($pattern)
     {
         if ($this instanceof ViewableInterface && $this->view() !== null) {
-            $route = $this->view()->render($pattern, $this->viewController());
+            $route = $this->view()->renderTemplate($pattern, $this->viewController());
         } else {
             $route = preg_replace_callback('~\{\{\s*(.*?)\s*\}\}~i', [ $this, 'parseRouteToken' ], $pattern);
         }

--- a/packages/property/src/Charcoal/Property/SpriteProperty.php
+++ b/packages/property/src/Charcoal/Property/SpriteProperty.php
@@ -209,7 +209,7 @@ class SpriteProperty extends AbstractProperty implements SelectablePropertyInter
                 '%icon%' => $val,
             ]);
 
-            $val = $this->view->render(
+            $val = $this->view->renderTemplate(
                 '<svg fill="currentColor" viewBox="0 0 25 25" height="40px" role="img" aria-label="' . $label . '">' .
                 '<use xlink:href="{{# withBaseUrl }}{{ spritePathWithHash }}{{/ withBaseUrl }}"></use>' .
                 '</svg>',
@@ -229,7 +229,7 @@ class SpriteProperty extends AbstractProperty implements SelectablePropertyInter
     public function spriteVal($val)
     {
         if ($val !== '') {
-            $val = $this->view->render(
+            $val = $this->view->renderTemplate(
                 '{{# withBaseUrl }}{{ spritePathWithHash }}{{/ withBaseUrl }}',
                 [
                     'spritePathWithHash' => $this->getSprite() . '#' . $val,

--- a/packages/view/src/Charcoal/View/AbstractView.php
+++ b/packages/view/src/Charcoal/View/AbstractView.php
@@ -68,7 +68,7 @@ abstract class AbstractView implements ViewInterface
      */
     public function renderTemplate(string $templateString, $context = null): string
     {
-        return $this->engine()->render($templateString, $context);
+        return $this->engine()->renderTemplate($templateString, $context);
     }
 
     /**


### PR DESCRIPTION
render and renderTemplate are generating errors using Twig engine. No error using Mustache since the
engine is calling the exact same core method for both of them but Twig doesn't. No modifications
implemented for admin package since it's only using Mustache.