### PR TITLE
Remove Composer dependency on paragonie/random_compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
         "league/flysystem": "^1.0",
         "mcaskill/php-html-build-attributes": "^1.0",
         "monolog/monolog": "^1.17",
-        "paragonie/random_compat": ">=2",
         "php": "^7.4 || ^8.0",
         "phpmailer/phpmailer": "~6.0",
         "pimple/pimple": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0021cae8e3c61006970742dfae5e98a3",
+    "content-hash": "c35f37a7e3f8ff284a81587245fee28f",
     "packages": [
         {
             "name": "barryvdh/elfinder-flysystem-driver",
@@ -1118,51 +1118,6 @@
                 "routing"
             ],
             "time": "2018-02-13T20:26:39+00:00"
-        },
-        {
-            "name": "paragonie/random_compat",
-            "version": "v9.99.100",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/996434e5492cb4c3edcb9168db6fbb1359ef965a",
-                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">= 7"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "4.*|5.*",
-                "vimeo/psalm": "^1"
-            },
-            "suggest": {
-                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
-            },
-            "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Paragon Initiative Enterprises",
-                    "email": "security@paragonie.com",
-                    "homepage": "https://paragonie.com"
-                }
-            ],
-            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
-            "keywords": [
-                "csprng",
-                "polyfill",
-                "pseudorandom",
-                "random"
-            ],
-            "time": "2020-10-15T08:29:30+00:00"
         },
         {
             "name": "phpmailer/phpmailer",

--- a/packages/admin/composer.json
+++ b/packages/admin/composer.json
@@ -39,7 +39,6 @@
         "charcoal/ui": "^3.2",
         "charcoal/user": "^3.2",
         "mcaskill/php-html-build-attributes": "^1.0",
-        "paragonie/random_compat": ">=2",
         "psr/cache": "^1.0",
         "psr/http-message": "^1.0",
         "psr/log": "^1.0",


### PR DESCRIPTION
Previously required to provide PHP 5 with support for CSPRNG functions added in PHP 7.