### PR TITLE
fix(releaserc): add parserOpts for commit analyser

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -14,7 +14,18 @@
         }
     ],
     "plugins": [
-        "@semantic-release/commit-analyzer",
+        [
+            "@semantic-release/commit-analyzer",
+            {
+                "parserOpts": {
+                    "noteKeywords": [
+                        "BREAKING CHANGE",
+                        "BREAKING CHANGES",
+                        "BREAKING"
+                    ]
+                }
+            }
+        ],
         [
             "@semantic-release/exec",
             {


### PR DESCRIPTION
fix a bug in which commit analyser wasn't detecting breaking changes