### PR TITLE
Update elfinder from 2.1.64 to 2.1.66

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,0 +1,15 @@
+name: charcoal
+type: php
+docroot: ""
+php_version: "7.4"
+webserver_type: apache-fpm
+xdebug_enabled: false
+additional_hostnames: []
+additional_fqdns: []
+database:
+    type: mariadb
+    version: "10.11"
+use_dns_when_possible: true
+composer_version: "2"
+web_environment: []
+corepack_enable: false

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "psr/log": "^1.0",
         "seld/jsonlint": "^1.9",
         "slim/slim": "^3.7",
-        "studio-42/elfinder": "2.1.64",
+        "studio-42/elfinder": "2.1.66",
         "symfony/translation": "^3.4",
         "tedivm/stash": "~0.16",
         "vlucas/phpdotenv": "^5.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "29faccd918f465a35b04d246acab37e4",
+    "content-hash": "4ac16967a85623889825a9dd486b4cf2",
     "packages": [
         {
             "name": "barryvdh/elfinder-flysystem-driver",
@@ -1952,16 +1952,16 @@
         },
         {
             "name": "studio-42/elfinder",
-            "version": "2.1.64",
+            "version": "2.1.66",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Studio-42/elFinder.git",
-                "reference": "deaa6797df1c6f288238b47284c9b593174bfc0f"
+                "reference": "78488951e44d69e8b9e4e849f8268df408632a6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Studio-42/elFinder/zipball/deaa6797df1c6f288238b47284c9b593174bfc0f",
-                "reference": "deaa6797df1c6f288238b47284c9b593174bfc0f",
+                "url": "https://api.github.com/repos/Studio-42/elFinder/zipball/78488951e44d69e8b9e4e849f8268df408632a6c",
+                "reference": "78488951e44d69e8b9e4e849f8268df408632a6c",
                 "shasum": ""
             },
             "require": {
@@ -2008,7 +2008,7 @@
             "homepage": "http://elfinder.org",
             "support": {
                 "issues": "https://github.com/Studio-42/elFinder/issues",
-                "source": "https://github.com/Studio-42/elFinder/tree/2.1.64"
+                "source": "https://github.com/Studio-42/elFinder/tree/2.1.66"
             },
             "funding": [
                 {
@@ -2016,7 +2016,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-20T07:43:10+00:00"
+            "time": "2025-08-28T11:51:22+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -6409,7 +6409,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -6421,6 +6421,6 @@
         "ext-simplexml": "*",
         "ext-spl": "*"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
There is currently a [security advisory](https://nvd.nist.gov/vuln/detail/CVE-2024-38909) for `studio-42/elfinder` v2.1.64. This updates it to a more recent patched version.